### PR TITLE
Fixed version for spring-cloud-commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>${org.springframework.cloud.version}</version>
+            <version>2.1.4.RELEASE</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Business Layer Application would not start.  Fixed version to 2.1.4 which is the latest and it now starts.  Latest was actually the variable in the ${org.springframework.cloud.version} but it looks as though it wasn't populating.  Tested on a number of developers machines and all experienced the same issue.  All tested and the application now starts.