### PR TITLE
Added single line fix for object comparison

### DIFF
--- a/src/main/java/uk/gov/ons/collection/entity/ValidationOverride.java
+++ b/src/main/java/uk/gov/ons/collection/entity/ValidationOverride.java
@@ -73,7 +73,7 @@ public class ValidationOverride {
 
         for (ValidationData validationDBData : validationDBList) {
             for (ValidationData validationUIData : validationUIList) {
-                if(validationDBData.getValidationOutputId() == validationUIData.getValidationOutputId()) {
+                if(validationDBData.getValidationOutputId().equals(validationUIData.getValidationOutputId())) {
                     if(validationUIData.isOverridden() != validationDBData.isOverridden()) {
                         validationDBData.setOverridden(validationUIData.isOverridden());
                         validationDBData.setLastupdatedBy(validationUIData.getLastupdatedBy());


### PR DESCRIPTION
Can you please review single line fix. ValidationOutputID object comparison is done using equals method.