### PR TITLE
Updated latest version of Jacoco plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The old version of Jacoco plugin stopped working in concourse. This Jacoco plugin is used for code coverage.  We need this fix in master for any emergency rebuild is required in integration or UAT environments.