### PR TITLE
Feature/spp 828 dateadjustment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <commons-io.version>1.3.2</commons-io.version>
         <jayway.com.version>2.4.0</jayway.com.version>
         <swagger.version>2.9.2</swagger.version>
-        <org.springframework.cloud.version>LATEST</org.springframework.cloud.version>
+        <org.springframework.cloud.version>2.2.6.RELEASE</org.springframework.cloud.version>
         <org.junit.jupiter.version>5.5.2</org.junit.jupiter.version>
         <org.junit.vintage.version>5.3.1</org.junit.vintage.version>
         <org.springframework.boot.version>2.0.5.RELEASE</org.springframework.boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <commons-io.version>1.3.2</commons-io.version>
         <jayway.com.version>2.4.0</jayway.com.version>
         <swagger.version>2.9.2</swagger.version>
-        <org.springframework.cloud.version>2.2.6.RELEASE</org.springframework.cloud.version>
+        <org.springframework.cloud.version>3.0.0</org.springframework.cloud.version>
         <org.junit.jupiter.version>5.5.2</org.junit.jupiter.version>
         <org.junit.vintage.version>5.3.1</org.junit.vintage.version>
         <org.springframework.boot.version>2.0.5.RELEASE</org.springframework.boot.version>
@@ -112,13 +112,13 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>${org.springframework.cloud.version}</version>
+            <version>2.2.6.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-kubernetes-hystrix</artifactId>
-            <version>${org.springframework.cloud.version}</version>
+            <version>0.2.1.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -19,7 +19,6 @@ import uk.gov.ons.collection.entity.DateAdjustmentQuery;
 import uk.gov.ons.collection.entity.DateAdjustmentResponse;
 import uk.gov.ons.collection.service.GraphQlService;
 
-import java.util.List;
 import java.util.Map;
 
 @Log4j2
@@ -68,7 +67,12 @@ public class DateAdjustmentController {
 
         try {
             log.info("API CALL!! --> /dateadjustment/saveOutput :: " + jsonString);
-
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(jsonString);
+            String saveQuery = dateAdjustmentResponse.buildSaveDateAdjustmentQuery();
+            log.info("GraphQL query for Date Adjustment save {}", saveQuery);
+            String saveResponseOutput = qlService.qlSearch(saveQuery);
+            log.info("Output after saving the Date Adjustment outputs {}", saveResponseOutput);
+            log.info("API Complete!! --> /selectiveediting/saveOutput");
         } catch (Exception err) {
             log.error("Exception found in Date Adjustment: " + err.getMessage());
             String message = processJsonErrorMessage(err);

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -34,7 +34,7 @@ public class DateAdjustmentController {
         log.info("API CALL!! --> /dateadjustment/loadconfigdata/{vars} :: " + params);
         String response = "{\n" +
                 "  \"reference\": \"49900613746\",\n" +
-                "  \"period\": \"201904\",\n" +
+                "  \"period\": \"201903\",\n" +
                 "  \"survey\": \"023\",\n" +
                 "  \"formid\": \"6\",\n" +
                 "  \"periodstart\": \"20190304\",\n" +
@@ -90,7 +90,7 @@ public class DateAdjustmentController {
                 "  \"weights\": [\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190304\",\n" +
+                "          \"tradingdate\": \"20190304\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.1,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -99,7 +99,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190305\",\n" +
+                "          \"tradingdate\": \"20190305\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.15,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -108,7 +108,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190306\",\n" +
+                "          \"tradingdate\": \"20190306\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.12,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -117,7 +117,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190307\",\n" +
+                "          \"tradingdate\": \"20190307\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.17,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -126,7 +126,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190308\",\n" +
+                "          \"tradingdate\": \"20190308\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.23,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -135,7 +135,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190309\",\n" +
+                "          \"tradingdate\": \"20190309\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.1,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -144,7 +144,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190310\",\n" +
+                "          \"tradingdate\": \"20190310\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.13,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -153,7 +153,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190311\",\n" +
+                "          \"tradingdate\": \"20190311\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.145,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -162,7 +162,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190312\",\n" +
+                "          \"tradingdate\": \"20190312\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.105,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -171,7 +171,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190313\",\n" +
+                "          \"tradingdate\": \"20190313\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.15,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -180,7 +180,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190314\",\n" +
+                "          \"tradingdate\": \"20190314\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.17,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -189,7 +189,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190315\",\n" +
+                "          \"tradingdate\": \"20190315\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.18,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -198,7 +198,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190316\",\n" +
+                "          \"tradingdate\": \"20190316\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.17,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -207,7 +207,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190317\",\n" +
+                "          \"tradingdate\": \"20190317\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.08,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -216,7 +216,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190318\",\n" +
+                "          \"tradingdate\": \"20190318\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -225,7 +225,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190319\",\n" +
+                "          \"tradingdate\": \"20190319\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -234,7 +234,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190320\",\n" +
+                "          \"tradingdate\": \"20190320\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -243,7 +243,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190321\",\n" +
+                "          \"tradingdate\": \"20190321\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -252,7 +252,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190322\",\n" +
+                "          \"tradingdate\": \"20190322\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.15,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -261,7 +261,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190323\",\n" +
+                "          \"tradingdate\": \"20190323\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.15,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -270,7 +270,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190324\",\n" +
+                "          \"tradingdate\": \"20190324\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -279,7 +279,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190325\",\n" +
+                "          \"tradingdate\": \"20190325\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.13,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -288,7 +288,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190326\",\n" +
+                "          \"tradingdate\": \"20190326\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.14,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -297,7 +297,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190327\",\n" +
+                "          \"tradingdate\": \"20190327\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.16,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -306,7 +306,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190328\",\n" +
+                "          \"tradingdate\": \"20190328\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.15,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -315,7 +315,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190329\",\n" +
+                "          \"tradingdate\": \"20190329\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.13,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -324,7 +324,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190330\",\n" +
+                "          \"tradingdate\": \"20190330\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.16,\n" +
                 "          \"period\": \"201903\",\n" +
@@ -333,7 +333,7 @@ public class DateAdjustmentController {
                 "        },\n" +
                 "        {\n" +
                 "          \"survey\": \"023\",\n" +
-                "          \"perioddate\": \"20190331\",\n" +
+                "          \"tradingdate\": \"20190331\",\n" +
                 "          \"domain\": 1,\n" +
                 "          \"weight\": 0.13,\n" +
                 "          \"period\": \"201903\",\n" +

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -15,7 +15,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.MatrixVariable;
 
+import uk.gov.ons.collection.entity.DateAdjustmentQuery;
+import uk.gov.ons.collection.entity.DateAdjustmentResponse;
 import uk.gov.ons.collection.service.GraphQlService;
+
+import java.util.List;
 import java.util.Map;
 
 @Log4j2
@@ -32,317 +36,23 @@ public class DateAdjustmentController {
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Successful retrieval of selective editing data", response = String.class)})
     public String loadDateAdjustmentData(@MatrixVariable Map<String, String> params) {
         log.info("API CALL!! --> /dateadjustment/loadconfigdata/{vars} :: " + params);
+        String response = "";
+        DateAdjustmentQuery dateAdjustmentQuery = null;
 
-        String response = "{\n" +
-                "  \"reference\": \"49900613746\",\n" +
-                "  \"period\": \"201903\",\n" +
-                "  \"survey\": \"023\",\n" +
-                "  \"formid\": \"6\",\n" +
-                "  \"periodstart\": \"20190304\",\n" +
-                "  \"periodend\": \"20190331\",\n" +
-                "  \"frozensic\": \"41100\",\n" +
-                "  \"domain\": 1,\n" +
-                "  \"cellnumber\": 1,\n" +
-                "  \"returnedstartdate\": \"20190401\",\n" +
-                "  \"returnedenddate\": \"20190430\",\n" +
-                "  \"longperiodparameter\": 35,\n" +
-                "  \"shortperiodparameter\": 27,\n" +
-                "  \"averageweekly\": true,\n" +
-                "  \"settomidpoint\": false,\n" +
-                "  \"settoequalweighted\": false,\n" +
-                "  \"usecalendardays\": false,\n" +
-                "  \"responses\": [\n" +
-                "    {\n" +
-                "      \"questioncode\": \"20\",\n" +
-                "      \"response\": \"10000\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"21\",\n" +
-                "      \"response\": \"500\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"22\",\n" +
-                "      \"response\": \"1000\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"23\",\n" +
-                "      \"response\": \"300\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"24\",\n" +
-                "      \"response\": \"900\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"25\",\n" +
-                "      \"response\": \"800\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"questioncode\": \"26\",\n" +
-                "      \"response\": \"200\",\n" +
-                "      \"instance\": \"0\"\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"weights\": [\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190304\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.1,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190305\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.15,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190306\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.12,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190307\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.17,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190308\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.23,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190309\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.1,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190310\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.13,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190311\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.145,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190312\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.105,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190313\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.15,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190314\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.17,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190315\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.18,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190316\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.17,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190317\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.08,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190318\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190319\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190320\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190321\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190322\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.15,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190323\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.15,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190324\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190325\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.13,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190326\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.14,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190327\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.16,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190328\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.15,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190329\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.13,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190330\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.16,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "          \"survey\": \"023\",\n" +
-                "          \"tradingdate\": \"20190331\",\n" +
-                "          \"domain\": 1,\n" +
-                "          \"weight\": 0.13,\n" +
-                "          \"period\": \"201903\",\n" +
-                "          \"periodstart\": \"20190304\",\n" +
-                "          \"periodend\": \"20190331\"\n" +
-                "        }\n" +
-                "      ]\n" +
-                "}";
+        try {
+            dateAdjustmentQuery = new DateAdjustmentQuery(params);
+            String queryStr = dateAdjustmentQuery.buildDateAdjustmentConfigQuery();
+            log.info("Date Adjustment configuration GraphQL query: " + queryStr);
+            String dateAdjustmentQueryOutput = qlService.qlSearch(queryStr);
+            log.info("Date Adjustment Query Output: " + dateAdjustmentQueryOutput);
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(dateAdjustmentQueryOutput);
+            response = dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+            log.info("Date Adjustment Response before sending to lambda: " + response);
+        } catch (Exception err) {
+            log.error("Exception found in Date Adjustment: " + err.getMessage());
+            String message = processJsonErrorMessage(err);
+            response = "{\"error\":\"Unable to load DateAdjustment config data " + message + "\"}";
+        }
 
         log.info("API Complete!! --> /dateadjustment/loadconfigdata");
 

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -1,0 +1,66 @@
+package uk.gov.ons.collection.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.MatrixVariable;
+
+import uk.gov.ons.collection.service.GraphQlService;
+import java.util.Map;
+
+@Log4j2
+@Api(value = "Date Adjustment Controller", description = "Entry points primarily involving date adjustment")
+@RestController
+@RequestMapping(value = "/dateadjustment")
+public class DateAdjustmentController {
+
+    @Autowired
+    GraphQlService qlService;
+
+    @ApiOperation(value = "Get all date adjustment data", response = String.class)
+    @GetMapping(value = "/loadconfigdata/{vars}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Successful retrieval of selective editing data", response = String.class)})
+    public String loadDateAdjustmentData(@MatrixVariable Map<String, String> params) {
+        log.info("API CALL!! --> /dateadjustment/loadconfigdata/{vars} :: " + params);
+        String response = "";
+
+        log.info("API Complete!! --> /dateadjustment/loadconfigdata");
+
+        return response;
+    }
+
+    @ApiOperation(value = "Save date adjustment calculation output", response = String.class)
+    @RequestMapping(value = "/saveOutput", method = { RequestMethod.POST, RequestMethod.PUT })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful save of date adjustment calculation outputs", response = String.class) })
+    @ResponseBody
+    public String saveDateAdjustmentOutput(@RequestBody String jsonString)  {
+
+        try {
+            log.info("API CALL!! --> /dateadjustment/saveOutput :: " + jsonString);
+
+        } catch (Exception err) {
+            log.error("Exception found in Date Adjustment: " + err.getMessage());
+            String message = processJsonErrorMessage(err);
+            return "{\"error\":\"Unable to save or update date adjustment data " + message + "\"}";
+        }
+        return "{\"Success\":\"Date Adjustment data saved successfully\"}";
+
+    }
+
+    private String processJsonErrorMessage(Exception err) {
+
+        String message = err.getMessage() != null ? err.getMessage().replace("\"","'") : "";
+        return message;
+    }
+}

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -32,6 +32,7 @@ public class DateAdjustmentController {
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Successful retrieval of selective editing data", response = String.class)})
     public String loadDateAdjustmentData(@MatrixVariable Map<String, String> params) {
         log.info("API CALL!! --> /dateadjustment/loadconfigdata/{vars} :: " + params);
+
         String response = "{\n" +
                 "  \"reference\": \"49900613746\",\n" +
                 "  \"period\": \"201903\",\n" +

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -32,7 +32,62 @@ public class DateAdjustmentController {
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Successful retrieval of selective editing data", response = String.class)})
     public String loadDateAdjustmentData(@MatrixVariable Map<String, String> params) {
         log.info("API CALL!! --> /dateadjustment/loadconfigdata/{vars} :: " + params);
-        String response = "";
+        String response = "{\n" +
+                "  \"reference\": \"49900613746\",\n" +
+                "  \"period\": \"201904\",\n" +
+                "  \"survey\": \"023\",\n" +
+                "  \"formid\": \"6\",\n" +
+                "  \"periodstart\": \"20190401\",\n" +
+                "  \"periodend\": \"20190430\",\n" +
+                "  \"frozensic\": \"41100\",\n" +
+                "  \"domain\": 1,\n" +
+                "  \"cellnumber\": 1,\n" +
+                "  \"returnedstartdate\": \"20190401\",\n" +
+                "  \"returnedenddate\": \"20190430\",\n" +
+                "  \"longperiodparameter\": 35,\n" +
+                "  \"shortperiodparameter\": 27,\n" +
+                "  \"averagewweekly\": true,\n" +
+                "  \"settomidpoint\": false,\n" +
+                "  \"settoequalweighted\": false,\n" +
+                "  \"usecalendardays\": false,\n" +
+                "  \"responses\": [\n" +
+                "    {\n" +
+                "      \"questioncode\": \"20\",\n" +
+                "      \"response\": \"10000\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"21\",\n" +
+                "      \"response\": \"500\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"22\",\n" +
+                "      \"response\": \"1000\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"23\",\n" +
+                "      \"response\": \"300\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"24\",\n" +
+                "      \"response\": \"900\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"25\",\n" +
+                "      \"response\": \"800\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"questioncode\": \"26\",\n" +
+                "      \"response\": \"200\",\n" +
+                "      \"instance\": \"0\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
 
         log.info("API Complete!! --> /dateadjustment/loadconfigdata");
 

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -37,8 +37,8 @@ public class DateAdjustmentController {
                 "  \"period\": \"201904\",\n" +
                 "  \"survey\": \"023\",\n" +
                 "  \"formid\": \"6\",\n" +
-                "  \"periodstart\": \"20190401\",\n" +
-                "  \"periodend\": \"20190430\",\n" +
+                "  \"periodstart\": \"20190304\",\n" +
+                "  \"periodend\": \"20190331\",\n" +
                 "  \"frozensic\": \"41100\",\n" +
                 "  \"domain\": 1,\n" +
                 "  \"cellnumber\": 1,\n" +
@@ -86,7 +86,261 @@ public class DateAdjustmentController {
                 "      \"response\": \"200\",\n" +
                 "      \"instance\": \"0\"\n" +
                 "    }\n" +
-                "  ]\n" +
+                "  ],\n" +
+                "  \"weights\": [\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190304\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.1,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190305\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.15,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190306\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.12,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190307\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.17,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190308\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.23,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190309\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.1,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190310\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.13,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190311\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.145,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190312\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.105,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190313\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.15,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190314\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.17,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190315\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.18,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190316\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.17,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190317\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.08,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190318\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190319\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190320\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190321\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190322\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.15,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190323\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.15,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190324\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190325\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.13,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190326\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.14,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190327\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.16,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190328\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.15,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190329\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.13,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190330\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.16,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"survey\": \"023\",\n" +
+                "          \"perioddate\": \"20190331\",\n" +
+                "          \"domain\": 1,\n" +
+                "          \"weight\": 0.13,\n" +
+                "          \"period\": \"201903\",\n" +
+                "          \"periodstart\": \"20190304\",\n" +
+                "          \"periodend\": \"20190331\"\n" +
+                "        }\n" +
+                "      ]\n" +
                 "}";
 
         log.info("API Complete!! --> /dateadjustment/loadconfigdata");

--- a/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/DateAdjustmentController.java
@@ -46,7 +46,7 @@ public class DateAdjustmentController {
                 "  \"returnedenddate\": \"20190430\",\n" +
                 "  \"longperiodparameter\": 35,\n" +
                 "  \"shortperiodparameter\": 27,\n" +
-                "  \"averagewweekly\": true,\n" +
+                "  \"averageweekly\": true,\n" +
                 "  \"settomidpoint\": false,\n" +
                 "  \"settoequalweighted\": false,\n" +
                 "  \"usecalendardays\": false,\n" +

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
@@ -25,8 +25,11 @@ public class DateAdjustmentQuery {
         selectiveEditingQuery.append(buildFilterCondition());
         selectiveEditingQuery.append("}) {");
         selectiveEditingQuery.append("nodes { survey period reference formid status frozensic resultscellnumber domain ");
-        selectiveEditingQuery.append("formByFormid {survey formid formdefinitionsByFormid(filter: {dateadjustment: {equalTo: true}}) {");
-        selectiveEditingQuery.append(" nodes { questioncode dateadjustment }}}");
+        selectiveEditingQuery.append("formByFormid {survey formid formdefinitionsByFormid {");
+        selectiveEditingQuery.append(" nodes { questioncode dateadjustment }}");
+        selectiveEditingQuery.append(" dateadjustmentreturndateconfigsByFormid {");
+        selectiveEditingQuery.append(" nodes { formid questioncode returndatetype }}");
+        selectiveEditingQuery.append("}");
         selectiveEditingQuery.append(" responsesByReferenceAndPeriodAndSurvey ");
         selectiveEditingQuery.append("{ nodes { reference period survey questioncode instance response }}}} ");
         selectiveEditingQuery.append("allDateadjustmentweightconfigs(filter: ");
@@ -35,7 +38,7 @@ public class DateAdjustmentQuery {
         selectiveEditingQuery.append("allContributordateadjustmentconfigs(filter: ");
         selectiveEditingQuery.append(buildFilterCondition());
         selectiveEditingQuery.append("}) ");
-        selectiveEditingQuery.append("{ nodes { reference period survey returnedstartdate returnedenddate longperiodparameter shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}");
+        selectiveEditingQuery.append("{ nodes { reference period survey longperiodparameter shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}");
         return selectiveEditingQuery.toString();
     }
 

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
@@ -20,26 +20,27 @@ public class DateAdjustmentQuery {
 
     public String buildDateAdjustmentConfigQuery() {
 
-        StringBuilder selectiveEditingQuery = new StringBuilder();
-        selectiveEditingQuery.append("{\"query\": \"query dateadjustmentconfig { allContributors(filter: ");
-        selectiveEditingQuery.append(buildFilterCondition());
-        selectiveEditingQuery.append("}) {");
-        selectiveEditingQuery.append("nodes { survey period reference formid status frozensic resultscellnumber domain ");
-        selectiveEditingQuery.append("formByFormid {survey formid formdefinitionsByFormid {");
-        selectiveEditingQuery.append(" nodes { questioncode dateadjustment }}");
-        selectiveEditingQuery.append(" dateadjustmentreturndateconfigsByFormid {");
-        selectiveEditingQuery.append(" nodes { formid questioncode returndatetype }}");
-        selectiveEditingQuery.append("}");
-        selectiveEditingQuery.append(" responsesByReferenceAndPeriodAndSurvey ");
-        selectiveEditingQuery.append("{ nodes { reference period survey questioncode instance response }}}} ");
-        selectiveEditingQuery.append("allDateadjustmentweightconfigs(filter: ");
-        selectiveEditingQuery.append(buildFilerConditionForSurveyAndPeriod());
-        selectiveEditingQuery.append("{ nodes { survey period tradingdate domain weight periodstart periodend }} ");
-        selectiveEditingQuery.append("allContributordateadjustmentconfigs(filter: ");
-        selectiveEditingQuery.append(buildFilterCondition());
-        selectiveEditingQuery.append("}) ");
-        selectiveEditingQuery.append("{ nodes { reference period survey longperiodparameter shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}");
-        return selectiveEditingQuery.toString();
+        StringBuilder dateAdjustmentQuery = new StringBuilder();
+        dateAdjustmentQuery.append("{\"query\": \"query dateadjustmentconfig { allContributors(filter: ");
+        dateAdjustmentQuery.append(buildFilterCondition());
+        dateAdjustmentQuery.append("}) {");
+        dateAdjustmentQuery.append("nodes { survey period reference formid status frozensic resultscellnumber domain ");
+        dateAdjustmentQuery.append("formByFormid {survey formid formdefinitionsByFormid {");
+        dateAdjustmentQuery.append(" nodes { questioncode dateadjustment }}");
+        dateAdjustmentQuery.append(" dateadjustmentreturndateconfigsByFormid {");
+        dateAdjustmentQuery.append(" nodes { formid questioncode returndatetype }}");
+        dateAdjustmentQuery.append("}");
+        dateAdjustmentQuery.append(" responsesByReferenceAndPeriodAndSurvey ");
+        dateAdjustmentQuery.append("{ nodes { reference period survey questioncode instance response }}}} ");
+        dateAdjustmentQuery.append("allDateadjustmentweightconfigs(filter: ");
+        dateAdjustmentQuery.append(buildFilerConditionForSurveyAndPeriod());
+        dateAdjustmentQuery.append("{ nodes { survey period tradingdate domain weight periodstart periodend }} ");
+        dateAdjustmentQuery.append("allContributordateadjustmentconfigs(filter: ");
+        dateAdjustmentQuery.append(buildFilterCondition());
+        dateAdjustmentQuery.append("}) ");
+        dateAdjustmentQuery.append("{ nodes { reference period survey longperiodparameter ");
+        dateAdjustmentQuery.append("shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}");
+        return dateAdjustmentQuery.toString();
     }
 
 

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentQuery.java
@@ -1,0 +1,94 @@
+package uk.gov.ons.collection.entity;
+
+import lombok.extern.log4j.Log4j2;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+public class DateAdjustmentQuery {
+
+    private HashMap<String, String> variables;
+    private static final String SURVEY = "survey";
+    private static final String PERIOD = "period";
+    private static final String REFERENCE = "reference";
+
+    public DateAdjustmentQuery(Map<String, String> variables) {
+        this.variables = (variables == null) ? new HashMap<>() : new HashMap<>(variables);
+    }
+
+    public String buildDateAdjustmentConfigQuery() {
+
+        StringBuilder selectiveEditingQuery = new StringBuilder();
+        selectiveEditingQuery.append("{\"query\": \"query dateadjustmentconfig { allContributors(filter: ");
+        selectiveEditingQuery.append(buildFilterCondition());
+        selectiveEditingQuery.append("}) {");
+        selectiveEditingQuery.append("nodes { survey period reference formid status frozensic resultscellnumber domain ");
+        selectiveEditingQuery.append("formByFormid {survey formid formdefinitionsByFormid(filter: {dateadjustment: {equalTo: true}}) {");
+        selectiveEditingQuery.append(" nodes { questioncode dateadjustment }}}");
+        selectiveEditingQuery.append(" responsesByReferenceAndPeriodAndSurvey ");
+        selectiveEditingQuery.append("{ nodes { reference period survey questioncode instance response }}}} ");
+        selectiveEditingQuery.append("allDateadjustmentweightconfigs(filter: ");
+        selectiveEditingQuery.append(buildFilerConditionForSurveyAndPeriod());
+        selectiveEditingQuery.append("{ nodes { survey period tradingdate domain weight periodstart periodend }} ");
+        selectiveEditingQuery.append("allContributordateadjustmentconfigs(filter: ");
+        selectiveEditingQuery.append(buildFilterCondition());
+        selectiveEditingQuery.append("}) ");
+        selectiveEditingQuery.append("{ nodes { reference period survey returnedstartdate returnedenddate longperiodparameter shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}");
+        return selectiveEditingQuery.toString();
+    }
+
+
+
+    public String buildFilterCondition() {
+        log.info("Reference : " + retrieveCurrentReference());
+        log.info("Survey : " + retrieveSurvey());
+        StringBuilder sbFilter = new StringBuilder();
+        sbFilter.append("{");
+        sbFilter.append("reference: {equalTo: ");
+        sbFilter.append("\\\"").append(retrieveCurrentReference());
+        sbFilter.append("\\\"}, survey: {equalTo: ");
+        sbFilter.append("\\\"").append(retrieveSurvey());
+        sbFilter.append("\\\"}, period: {equalTo: ");
+        sbFilter.append("\\\"").append(retrieveCurrentPeriod()).append("\\\"");
+        sbFilter.append("}");
+        return sbFilter.toString();
+    }
+
+    public  String buildFilerConditionForSurveyAndPeriod() {
+        StringBuilder sbFilter = new StringBuilder();
+        sbFilter.append("{");
+        sbFilter.append("survey: {equalTo: ");
+        sbFilter.append("\\\"").append(retrieveSurvey());
+        sbFilter.append("\\\"}, period: {equalTo: ");
+        sbFilter.append("\\\"").append(retrieveCurrentPeriod());
+        sbFilter.append("\\\"}}) ");
+        return sbFilter.toString();
+
+    }
+
+    public String retrieveCurrentReference() throws NullPointerException {
+        String reference = variables.get(REFERENCE);
+        if (reference == null) {
+            throw new NullPointerException("There is a problem and UI is not sending Reference");
+        }
+        return reference;
+    }
+
+    public String retrieveCurrentPeriod() throws NullPointerException {
+        String period = variables.get(PERIOD);
+        if (period == null) {
+            throw new NullPointerException("There is a problem and UI is not sending Current Period");
+        }
+        return period;
+    }
+
+    public String retrieveSurvey() throws NullPointerException {
+        String survey = variables.get(SURVEY);
+        if (survey == null) {
+            throw new NullPointerException("There is a problem and UI is not sending Survey");
+        }
+        return survey;
+    }
+}

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -241,8 +241,8 @@ public class DateAdjustmentResponse {
         JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data").getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
         if (contributorDateAdjustmentConfigArray.length() > 0) {
             JSONObject contributorConfigObject = contributorDateAdjustmentConfigArray.getJSONObject(0);
-            selectiveEditingResultObj.put(RETURNED_START_DATE, contributorConfigObject.getString(RETURNED_START_DATE));
-            selectiveEditingResultObj.put(RETURNED_END_DATE, contributorConfigObject.getString(RETURNED_END_DATE));
+            //selectiveEditingResultObj.put(RETURNED_START_DATE, contributorConfigObject.getString(RETURNED_START_DATE));
+            //selectiveEditingResultObj.put(RETURNED_END_DATE, contributorConfigObject.getString(RETURNED_END_DATE));
             selectiveEditingResultObj.put(LONG_PERIOD_PARAMETER, contributorConfigObject.get(LONG_PERIOD_PARAMETER));
             selectiveEditingResultObj.put(SHORT_PERIOD_PARAMETER, contributorConfigObject.get(SHORT_PERIOD_PARAMETER));
             selectiveEditingResultObj.put(AVERAGE_WEEKLY, contributorConfigObject.get(AVERAGE_WEEKLY));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -13,7 +13,9 @@ public class DateAdjustmentResponse {
     private static final String REFERENCE = "reference";
     private static final String PERIOD = "period";
     private static final String SURVEY = "survey";
-    private static final String RESULTS_CELL_NUMBER = "cellnumber";
+    private static final String RESULTS_CELL_NUMBER = "resultscellnumber";
+    private static final String CELL_NUMBER = "cellnumber";
+
     private static final String DOMAIN = "domain";
     private static final String QUESTION_CODE = "questioncode";
     private static final String RESPONSE = "response";
@@ -70,7 +72,7 @@ public class DateAdjustmentResponse {
                 cellNumber = contributorObject.getInt(RESULTS_CELL_NUMBER);
                 log.info("Domain for a given contributor: " + domain);
                 log.info("Results Cell Number for a given contributor: " + cellNumber);
-                dateAdjustmentResultObj.put(RESULTS_CELL_NUMBER, cellNumber);
+                dateAdjustmentResultObj.put(CELL_NUMBER, cellNumber);
                 dateAdjustmentResultObj.put(DOMAIN, domain);
                 processDateAdjustmentWeightConfiguration(domain, dateAdjustmentResultObj);
                 processContributorDateAdjustmentConfiguration(dateAdjustmentResultObj);
@@ -104,7 +106,7 @@ public class DateAdjustmentResponse {
                     String response = responseArray.getJSONObject(j).getString(RESPONSE);
                     if(questionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE))) {
                         eachResponseObject.put(RESPONSE, response);
-                        eachResponseObject.put(INSTANCE, responseArray.getJSONObject(j).getString(INSTANCE));
+                        eachResponseObject.put(INSTANCE, responseArray.getJSONObject(j).get(INSTANCE));
                     }
                 }
                 responseResultArr.put(eachResponseObject);

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -272,8 +272,6 @@ public class DateAdjustmentResponse {
         JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data").getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
         if (contributorDateAdjustmentConfigArray.length() > 0) {
             JSONObject contributorConfigObject = contributorDateAdjustmentConfigArray.getJSONObject(0);
-            //selectiveEditingResultObj.put(RETURNED_START_DATE, contributorConfigObject.getString(RETURNED_START_DATE));
-            //selectiveEditingResultObj.put(RETURNED_END_DATE, contributorConfigObject.getString(RETURNED_END_DATE));
             selectiveEditingResultObj.put(LONG_PERIOD_PARAMETER, contributorConfigObject.get(LONG_PERIOD_PARAMETER));
             selectiveEditingResultObj.put(SHORT_PERIOD_PARAMETER, contributorConfigObject.get(SHORT_PERIOD_PARAMETER));
             selectiveEditingResultObj.put(AVERAGE_WEEKLY, contributorConfigObject.get(AVERAGE_WEEKLY));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -95,8 +95,10 @@ public class DateAdjustmentResponse {
             joiner.add("survey: \\\"" + jsonQlResponse.getString("survey") + "\\\"");
             joiner.add("questioncode: \\\"" + data.getString("questioncode") + "\\\"");
             joiner.add("instance: 0");
-            joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\"");
-            joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\"");
+            joiner = (data.get("adjusted_value") == null) ? (joiner.add("adjustedresponse: " + null))
+                    : (joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\""));
+            joiner = (data.get("average_weekly_value") == null) ? (joiner.add("averageweeklyadjustedresponse: " + null))
+                    : (joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\""));
             joiner.add("createdby: \\\"fisdba\\\"");
             joiner.add("createddate: \\\"" + time.toString() + "\\\"");
             joiner.add("lastupdatedby: \\\"fisdba\\\"");
@@ -117,6 +119,7 @@ public class DateAdjustmentResponse {
             joiner.add("period: \\\"" + jsonQlResponse.getString("period") + "\\\"");
             joiner.add("survey: \\\"" + jsonQlResponse.getString("survey") + "\\\"");
             joiner.add("dateadjustmenterrorflag: \\\"" + jsonQlResponse.get("dateadjustmenterrorflag") + "\\\"");
+            joiner.add("dateadjustmentlengthflag: \\\"" + jsonQlResponse.get("dateadjustmentlengthflag") + "\\\"");
             joiner.add("actualdaysreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));
             joiner.add("daysreturnedperiod: " + jsonQlResponse.get("daysreturnedperiod"));
             joiner.add("sumtradingweightsoverreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -41,6 +41,7 @@ public class DateAdjustmentResponse {
     private static final String SET_MID_POINT = "settomidpoint";
     private static final String SET_EQUAL_WEIGHTED = "settoequalweighted";
     private static final String USE_CALENDAR_DAYS = "usecalendardays";
+    private static final String RETURNED_DATE_TYPE = "returndatetype";
 
 
     private static final String EMPTY_RESPONSE = "";
@@ -212,8 +213,8 @@ public class DateAdjustmentResponse {
 
         if(returnedDateConfigArray.length() > 0 && responseArray.length() > 0) {
             for (int i = 0; i < returnedDateConfigArray.length(); i++) {
-                String returnQuestionCode = returnedDateConfigArray.getJSONObject(i).getString("questioncode");
-                String returnType = returnedDateConfigArray.getJSONObject(i).getString("returndatetype");
+                String returnQuestionCode = returnedDateConfigArray.getJSONObject(i).getString(QUESTION_CODE);
+                String returnType = returnedDateConfigArray.getJSONObject(i).getString(RETURNED_DATE_TYPE);
                 for (int j = 0; j < responseArray.length(); j++) {
                     if(returnQuestionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE))) {
                         if (returnType.equals("S")) {

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -115,8 +115,7 @@ public class DateAdjustmentResponse {
             joiner.add("reference: \\\"" + jsonQlResponse.getString("reference") + "\\\"");
             joiner.add("period: \\\"" + jsonQlResponse.getString("period") + "\\\"");
             joiner.add("survey: \\\"" + jsonQlResponse.getString("survey") + "\\\"");
-            joiner.add("errorflag: \\\"" + jsonQlResponse.getString("errorflag") + "\\\"");
-            joiner.add("dateadjustmenterrorflag: \\\"" + jsonQlResponse.getString("dateadjustmenterrorflag") + "\\\"");
+            joiner.add("dateadjustmenterrorflag: \\\"" + jsonQlResponse.get("dateadjustmenterrorflag") + "\\\"");
             joiner.add("actualdaysreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));
             joiner.add("daysreturnedperiod: " + jsonQlResponse.get("daysreturnedperiod"));
             joiner.add("sumtradingweightsoverreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -117,6 +117,7 @@ public class DateAdjustmentResponse {
             joiner.add("survey: \\\"" + jsonQlResponse.getString("survey") + "\\\"");
             joiner.add("errorflag: \\\"" + jsonQlResponse.getString("errorflag") + "\\\"");
             joiner.add("dateadjustmenterrorflag: \\\"" + jsonQlResponse.getString("dateadjustmenterrorflag") + "\\\"");
+            joiner.add("actualdaysreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));
             joiner.add("daysreturnedperiod: " + jsonQlResponse.get("daysreturnedperiod"));
             joiner.add("sumtradingweightsoverreturnedperiod: " + jsonQlResponse.get("actualdaysreturnedperiod"));
             joiner.add("sumtradingweightsoveractualreturnedperiod: " + jsonQlResponse.get("sumtradingweightsoveractualreturnedperiod"));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -97,12 +97,12 @@ public class DateAdjustmentResponse {
             joiner.add("questioncode: \\\"" + data.getString("questioncode") + "\\\"");
             joiner.add("instance: 0");
 
-            joiner = (data.get("adjusted_value") == null || data.get("adjusted_value").toString().equals("null") ) ?
-                    (joiner.add("adjustedresponse: \\\"" + EMPTY_SPACE + "\\\"")) :
-                    (joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\""));
-            joiner = (data.get("average_weekly_value") == null || data.get("average_weekly_value").toString().equals("null") ) ?
-                    (joiner.add("averageweeklyadjustedresponse: \\\"" + EMPTY_SPACE + "\\\"")) :
-                    (joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\""));
+            joiner = (data.get("adjusted_value") == null || data.get("adjusted_value").toString().equals("null"))
+                    ? (joiner.add("adjustedresponse: \\\"" + EMPTY_SPACE + "\\\""))
+                    : (joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\""));
+            joiner = (data.get("average_weekly_value") == null || data.get("average_weekly_value").toString().equals("null"))
+                    ? (joiner.add("averageweeklyadjustedresponse: \\\"" + EMPTY_SPACE + "\\\""))
+                    : (joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\""));
             joiner.add("createdby: \\\"fisdba\\\"");
             joiner.add("createddate: \\\"" + time.toString() + "\\\"");
             joiner.add("lastupdatedby: \\\"fisdba\\\"");
@@ -166,17 +166,20 @@ public class DateAdjustmentResponse {
                 dateAdjustmentResultObj.put(CELL_NUMBER, cellNumber);
                 dateAdjustmentResultObj.put(DOMAIN, domain);
                 processDateAdjustmentWeightConfiguration(domain, dateAdjustmentResultObj);
-                JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data").getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
+                JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data")
+                        .getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
                 processContributorDateAdjustmentConfiguration(dateAdjustmentResultObj);
 
                 processResponses(contributorObject, dateAdjustmentResultObj);
 
             } else {
-                throw new InvalidJsonException("There is no contributor for a given survey, reference and periods. Please verify");
+                throw new InvalidJsonException("There is no contributor for a given survey, " +
+                        "reference and periods. Please verify");
             }
 
         } catch (Exception e) {
-            throw new InvalidJsonException("Problem in parsing Selective Editing GraphQL responses " + e.getMessage(), e);
+            throw new InvalidJsonException("Problem in parsing Selective Editing " +
+                    "GraphQL responses " + e.getMessage(), e);
         }
         return dateAdjustmentResultObj.toString();
     }
@@ -186,7 +189,8 @@ public class DateAdjustmentResponse {
 
         JSONArray responseResultArr = new JSONArray();
         JSONArray formDefinitionArray = contributorObject.getJSONObject("formByFormid").getJSONObject("formdefinitionsByFormid").getJSONArray("nodes");
-        JSONArray returnedDateConfigArray = contributorObject.getJSONObject("formByFormid").getJSONObject("dateadjustmentreturndateconfigsByFormid").getJSONArray("nodes");
+        JSONArray returnedDateConfigArray = contributorObject.getJSONObject("formByFormid")
+                .getJSONObject("dateadjustmentreturndateconfigsByFormid").getJSONArray("nodes");
         JSONArray responseArray = contributorObject.getJSONObject("responsesByReferenceAndPeriodAndSurvey").getJSONArray("nodes");
         if (formDefinitionArray.length() > 0) {
             for (int i = 0; i < formDefinitionArray.length(); i++) {
@@ -195,9 +199,9 @@ public class DateAdjustmentResponse {
                 var eachResponseObject = new JSONObject();
                 boolean dateAdjustmentFlag = eachFormDefinitionObject.getBoolean("dateadjustment");
                 boolean matchFound = false;
-                for (int j = 0; j< responseArray.length(); j++) {
+                for (int j = 0; j < responseArray.length(); j++) {
                     String response = responseArray.getJSONObject(j).getString(RESPONSE);
-                    if(questionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE)) && dateAdjustmentFlag) {
+                    if (questionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE)) && dateAdjustmentFlag) {
                         eachResponseObject.put(QUESTION_CODE, questionCode);
                         eachResponseObject.put(RESPONSE, response);
                         eachResponseObject.put(INSTANCE, responseArray.getJSONObject(j).get(INSTANCE));
@@ -205,7 +209,7 @@ public class DateAdjustmentResponse {
                         matchFound = true;
                     }
                 }
-                if(!matchFound && dateAdjustmentFlag) {
+                if (!matchFound && dateAdjustmentFlag) {
                     eachResponseObject.put(QUESTION_CODE, questionCode);
                     eachResponseObject.put(RESPONSE, EMPTY_RESPONSE);
                     eachResponseObject.put(INSTANCE, EMPTY_RESPONSE);
@@ -218,12 +222,12 @@ public class DateAdjustmentResponse {
             throw new InvalidJsonException("There is no FormDefinition for a given survey. Please verify");
         }
 
-        if(returnedDateConfigArray.length() > 0 && responseArray.length() > 0) {
+        if (returnedDateConfigArray.length() > 0 && responseArray.length() > 0) {
             for (int i = 0; i < returnedDateConfigArray.length(); i++) {
                 String returnQuestionCode = returnedDateConfigArray.getJSONObject(i).getString(QUESTION_CODE);
                 String returnType = returnedDateConfigArray.getJSONObject(i).getString(RETURNED_DATE_TYPE);
                 for (int j = 0; j < responseArray.length(); j++) {
-                    if(returnQuestionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE))) {
+                    if (returnQuestionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE))) {
                         if (returnType.equals("S")) {
                             selectiveEditingResultObj.put(RETURNED_START_DATE, responseArray.getJSONObject(j).getString(RESPONSE));
 
@@ -268,7 +272,8 @@ public class DateAdjustmentResponse {
             if (tradingConfigResultArr.length() > 0) {
                 selectiveEditingResultObj.put(WEIGHT_CONFIG, tradingConfigResultArr);
             } else {
-                throw new InvalidJsonException("There are no trading weights for a given survey, period and domain in the trading weight contributor. Please verify");
+                throw new InvalidJsonException("There are no trading weights for a given survey, " +
+                        "period and domain in the trading weight contributor. Please verify");
             }
         } else {
             throw new InvalidJsonException("There is no trading weight configuration. Please verify");
@@ -277,7 +282,8 @@ public class DateAdjustmentResponse {
     }
 
     private void processContributorDateAdjustmentConfiguration(JSONObject selectiveEditingResultObj) throws InvalidJsonException {
-        JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data").getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
+        JSONArray contributorDateAdjustmentConfigArray = jsonQlResponse.getJSONObject("data")
+                .getJSONObject("allContributordateadjustmentconfigs").getJSONArray("nodes");
         if (contributorDateAdjustmentConfigArray.length() > 0) {
             JSONObject contributorConfigObject = contributorDateAdjustmentConfigArray.getJSONObject(0);
             selectiveEditingResultObj.put(LONG_PERIOD_PARAMETER, contributorConfigObject.get(LONG_PERIOD_PARAMETER));

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -42,6 +42,7 @@ public class DateAdjustmentResponse {
     private static final String SET_EQUAL_WEIGHTED = "settoequalweighted";
     private static final String USE_CALENDAR_DAYS = "usecalendardays";
     private static final String RETURNED_DATE_TYPE = "returndatetype";
+    private static final String EMPTY_SPACE = "";
 
 
     private static final String EMPTY_RESPONSE = "";
@@ -95,10 +96,13 @@ public class DateAdjustmentResponse {
             joiner.add("survey: \\\"" + jsonQlResponse.getString("survey") + "\\\"");
             joiner.add("questioncode: \\\"" + data.getString("questioncode") + "\\\"");
             joiner.add("instance: 0");
-            joiner = (data.get("adjusted_value") == null) ? (joiner.add("adjustedresponse: " + null))
-                    : (joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\""));
-            joiner = (data.get("average_weekly_value") == null) ? (joiner.add("averageweeklyadjustedresponse: " + null))
-                    : (joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\""));
+
+            joiner = (data.get("adjusted_value") == null || data.get("adjusted_value").toString().equals("null") ) ?
+                    (joiner.add("adjustedresponse: \\\"" + EMPTY_SPACE + "\\\"")) :
+                    (joiner.add("adjustedresponse: \\\"" + data.get("adjusted_value") + "\\\""));
+            joiner = (data.get("average_weekly_value") == null || data.get("average_weekly_value").toString().equals("null") ) ?
+                    (joiner.add("averageweeklyadjustedresponse: \\\"" + EMPTY_SPACE + "\\\"")) :
+                    (joiner.add("averageweeklyadjustedresponse: \\\"" + data.get("average_weekly_value") + "\\\""));
             joiner.add("createdby: \\\"fisdba\\\"");
             joiner.add("createddate: \\\"" + time.toString() + "\\\"");
             joiner.add("lastupdatedby: \\\"fisdba\\\"");

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -287,7 +287,7 @@ public class DateAdjustmentResponse {
             selectiveEditingResultObj.put(SET_EQUAL_WEIGHTED, contributorConfigObject.get(SET_EQUAL_WEIGHTED));
             selectiveEditingResultObj.put(USE_CALENDAR_DAYS, contributorConfigObject.get(USE_CALENDAR_DAYS));
         } else {
-            throw new InvalidJsonException("There is no domain configuration. Please verify");
+            throw new InvalidJsonException("There is no contributor date adjustment configuration. Please verify");
         }
 
     }

--- a/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
@@ -148,7 +148,7 @@ public class HistoryDetailsResponse {
             for (int l = 0; l < responseArray.length(); l++) {
                 if (viewFormResponsesArray.getJSONObject(k).getString("questioncode").equals(responseArray.getJSONObject(l)
                         .getString("questioncode"))) {
-                    viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).getString("response"));
+                    viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
                     viewFormResponsesArray.getJSONObject(k).put("instance", responseArray.getJSONObject(l).getInt("instance"));
                 }
             }

--- a/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
@@ -148,15 +148,11 @@ public class HistoryDetailsResponse {
             for (int l = 0; l < responseArray.length(); l++) {
                 if (viewFormResponsesArray.getJSONObject(k).getString("questioncode").equals(responseArray.getJSONObject(l)
                         .getString("questioncode"))) {
-                    //Add null check
                     if(responseArray.getJSONObject(l).isNull("response")){
                         viewFormResponsesArray.getJSONObject(k).put("response", "");
-                    }
-                    else{
+                    } else {
                         viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
                     }
-                    //End of Adding
-                    //viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
                     viewFormResponsesArray.getJSONObject(k).put("instance", responseArray.getJSONObject(l).getInt("instance"));
                 }
             }

--- a/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/HistoryDetailsResponse.java
@@ -148,7 +148,15 @@ public class HistoryDetailsResponse {
             for (int l = 0; l < responseArray.length(); l++) {
                 if (viewFormResponsesArray.getJSONObject(k).getString("questioncode").equals(responseArray.getJSONObject(l)
                         .getString("questioncode"))) {
-                    viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
+                    //Add null check
+                    if(responseArray.getJSONObject(l).isNull("response")){
+                        viewFormResponsesArray.getJSONObject(k).put("response", "");
+                    }
+                    else{
+                        viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
+                    }
+                    //End of Adding
+                    //viewFormResponsesArray.getJSONObject(k).put("response", responseArray.getJSONObject(l).get("response"));
                     viewFormResponsesArray.getJSONObject(k).put("instance", responseArray.getJSONObject(l).getInt("instance"));
                 }
             }

--- a/src/main/java/uk/gov/ons/collection/entity/ViewFormResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/ViewFormResponse.java
@@ -89,7 +89,15 @@ public class ViewFormResponse {
         for(int i = 0; i < outputFormArray.length(); i++){
             for(int j = 0; j < responseArray.length(); j++){
                 if(outputFormArray.getJSONObject(i).getString("questioncode").equals(responseArray.getJSONObject(j).getString("questioncode"))) {
-                    outputFormArray.getJSONObject(i).put("response", responseArray.getJSONObject(j).getString("response"));
+                    //Adding
+                    if(responseArray.getJSONObject(j).isNull("response")){
+                        outputFormArray.getJSONObject(i).put("response", "");
+                    }
+                    else{
+                        outputFormArray.getJSONObject(i).put("response", responseArray.getJSONObject(j).getString("response"));
+                    }
+                    //End of Adding
+                    //outputFormArray.getJSONObject(i).put("response", responseArray.getJSONObject(j).getString("response"));
                     if(responseArray.getJSONObject(j).isNull("adjustedresponse")){
                         outputFormArray.getJSONObject(i).put("adjustedresponse", "");
                     }

--- a/src/main/java/uk/gov/ons/collection/entity/ViewFormResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/ViewFormResponse.java
@@ -89,15 +89,12 @@ public class ViewFormResponse {
         for(int i = 0; i < outputFormArray.length(); i++){
             for(int j = 0; j < responseArray.length(); j++){
                 if(outputFormArray.getJSONObject(i).getString("questioncode").equals(responseArray.getJSONObject(j).getString("questioncode"))) {
-                    //Adding
                     if(responseArray.getJSONObject(j).isNull("response")){
                         outputFormArray.getJSONObject(i).put("response", "");
                     }
                     else{
                         outputFormArray.getJSONObject(i).put("response", responseArray.getJSONObject(j).getString("response"));
                     }
-                    //End of Adding
-                    //outputFormArray.getJSONObject(i).put("response", responseArray.getJSONObject(j).getString("response"));
                     if(responseArray.getJSONObject(j).isNull("adjustedresponse")){
                         outputFormArray.getJSONObject(i).put("adjustedresponse", "");
                     }

--- a/src/main/java/uk/gov/ons/collection/utilities/UpsertResponse.java
+++ b/src/main/java/uk/gov/ons/collection/utilities/UpsertResponse.java
@@ -105,7 +105,13 @@ public class UpsertResponse {
             response.setSurvey(outputArray.getJSONObject(i).getString("survey"));
             response.setPeriod(outputArray.getJSONObject(i).getString("period"));
             response.setQuestionCode(outputArray.getJSONObject(i).getString("questioncode"));
-            response.setResponse(outputArray.getJSONObject(i).getString("response"));
+            if(outputArray.getJSONObject(i).isNull("response")){
+                response.setResponse("");
+            }
+            else{
+                response.setResponse(outputArray.getJSONObject(i).getString("response"));
+            }
+            //response.setResponse(outputArray.getJSONObject(i).getString("response"));
             response.setCreatedBy(outputArray.getJSONObject(i).getString("createdby"));
             response.setCreatedDate(outputArray.getJSONObject(i).getString("createddate"));
             response.setInstance(outputArray.getJSONObject(i).getInt("instance"));

--- a/src/main/java/uk/gov/ons/collection/utilities/UpsertResponse.java
+++ b/src/main/java/uk/gov/ons/collection/utilities/UpsertResponse.java
@@ -107,11 +107,9 @@ public class UpsertResponse {
             response.setQuestionCode(outputArray.getJSONObject(i).getString("questioncode"));
             if(outputArray.getJSONObject(i).isNull("response")){
                 response.setResponse("");
-            }
-            else{
+            } else {
                 response.setResponse(outputArray.getJSONObject(i).getString("response"));
             }
-            //response.setResponse(outputArray.getJSONObject(i).getString("response"));
             response.setCreatedBy(outputArray.getJSONObject(i).getString("createdby"));
             response.setCreatedDate(outputArray.getJSONObject(i).getString("createddate"));
             response.setInstance(outputArray.getJSONObject(i).getInt("instance"));

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
@@ -1,0 +1,4 @@
+package uk.gov.ons.collection.test;
+
+public class DateAdjustmentQueryTest {
+}

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
@@ -6,6 +6,9 @@ import uk.gov.ons.collection.entity.DateAdjustmentQuery;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class DateAdjustmentQueryTest {
     Map<String,String> parameters = new HashMap<>();
 
@@ -15,8 +18,33 @@ public class DateAdjustmentQueryTest {
         parameters.put("reference", "49900534932");
         parameters.put("period", "201904");
         parameters.put("survey", "023");
+        String expectedQuery = "{\"query\": \"query dateadjustmentconfig { allContributors(filter: {reference: {equalTo: \\\"49900534932\\\"}, survey: {equalTo: \\\"023\\\"}, period: {equalTo: \\\"201904\\\"}}) {nodes { survey period reference formid status frozensic resultscellnumber domain formByFormid {survey formid formdefinitionsByFormid { nodes { questioncode dateadjustment }} dateadjustmentreturndateconfigsByFormid { nodes { formid questioncode returndatetype }}} responsesByReferenceAndPeriodAndSurvey { nodes { reference period survey questioncode instance response }}}} allDateadjustmentweightconfigs(filter: {survey: {equalTo: \\\"023\\\"}, period: {equalTo: \\\"201904\\\"}}) { nodes { survey period tradingdate domain weight periodstart periodend }} allContributordateadjustmentconfigs(filter: {reference: {equalTo: \\\"49900534932\\\"}, survey: {equalTo: \\\"023\\\"}, period: {equalTo: \\\"201904\\\"}}) { nodes { reference period survey longperiodparameter shortperiodparameter averageweekly settomidpoint settoequalweighted usecalendardays }}}\"}";
         DateAdjustmentQuery dateAdjustmentQuery = new DateAdjustmentQuery(parameters);
-        String graphQLQuery = dateAdjustmentQuery.buildDateAdjustmentConfigQuery();
-        System.out.println(graphQLQuery);
+        String actualGraphQLQuery = dateAdjustmentQuery.buildDateAdjustmentConfigQuery();
+        assertEquals(expectedQuery, actualGraphQLQuery);
+    }
+
+    @Test
+    void verify_null_input_parameters_date_adjustment_input_data_ThrowsAnException() {
+        Map<String,String> parameters = null;
+        DateAdjustmentQuery dateAdjustmentQuery = new DateAdjustmentQuery(parameters);
+        assertThrows(NullPointerException.class, () -> dateAdjustmentQuery.retrieveCurrentReference());
+        assertThrows(NullPointerException.class, () -> dateAdjustmentQuery.retrieveSurvey());
+        assertThrows(NullPointerException.class, () -> dateAdjustmentQuery.retrieveCurrentPeriod());
+    }
+
+    @Test
+    void verify_input_parameters_date_adjustment_data() {
+        String expectedReference = "49900534932";
+        String expectedPeriod = "201904";
+        String expectedSurvey = "023";
+        parameters.put("reference", "49900534932");
+        parameters.put("period", "201904");
+        parameters.put("survey", "023");
+        DateAdjustmentQuery dateAdjustmentQuery = new DateAdjustmentQuery(parameters);
+
+        assertEquals(expectedReference, dateAdjustmentQuery.retrieveCurrentReference());
+        assertEquals(expectedPeriod, dateAdjustmentQuery.retrieveCurrentPeriod());
+        assertEquals(expectedSurvey, dateAdjustmentQuery.retrieveSurvey());
     }
 }

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentQueryTest.java
@@ -1,4 +1,22 @@
 package uk.gov.ons.collection.test;
 
+import org.junit.jupiter.api.Test;
+import uk.gov.ons.collection.entity.DateAdjustmentQuery;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class DateAdjustmentQueryTest {
+    Map<String,String> parameters = new HashMap<>();
+
+
+    @Test
+    void verify_date_adjustment_graphql_query() {
+        parameters.put("reference", "49900534932");
+        parameters.put("period", "201904");
+        parameters.put("survey", "023");
+        DateAdjustmentQuery dateAdjustmentQuery = new DateAdjustmentQuery(parameters);
+        String graphQLQuery = dateAdjustmentQuery.buildDateAdjustmentConfigQuery();
+        System.out.println(graphQLQuery);
+    }
 }

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -62,19 +62,63 @@ public class DateAdjustmentResponseTest {
             "    \"allContributors\": {\n" +
             "      \"nodes\": [\n" +
             "        {\n" +
-            "          \"reference\": \"49900748571\",\n" +
-            "          \"period\": \"201903\",\n" +
             "          \"survey\": \"023\",\n" +
-            "          \"formid\": 7,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
             "          \"status\": \"Form saved\",\n" +
             "          \"frozensic\": \"41100\",\n" +
             "          \"resultscellnumber\": 1,\n" +
             "          \"domain\": 1,\n" +
             "          \"formByFormid\": {\n" +
             "            \"survey\": \"023\",\n" +
-            "            \"formid\": 7,\n" +
+            "            \"formid\": 5,\n" +
             "            \"formdefinitionsByFormid\": {\n" +
             "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146a\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146b\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146c\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146d\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146e\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146f\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146g\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"146h\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
             "                {\n" +
             "                  \"questioncode\": \"20\",\n" +
             "                  \"dateadjustment\": true\n" +
@@ -82,30 +126,20 @@ public class DateAdjustmentResponseTest {
             "                {\n" +
             "                  \"questioncode\": \"21\",\n" +
             "                  \"dateadjustment\": true\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"returndatetype\": \"S\"\n" +
             "                },\n" +
             "                {\n" +
-            "                  \"questioncode\": \"22\",\n" +
-            "                  \"dateadjustment\": true\n" +
-            "                },\n" +
-            "                {\n" +
-            "                  \"questioncode\": \"23\",\n" +
-            "                  \"dateadjustment\": true\n" +
-            "                },\n" +
-            "                {\n" +
-            "                  \"questioncode\": \"24\",\n" +
-            "                  \"dateadjustment\": true\n" +
-            "                },\n" +
-            "                {\n" +
-            "                  \"questioncode\": \"25\",\n" +
-            "                  \"dateadjustment\": true\n" +
-            "                },\n" +
-            "                {\n" +
-            "                  \"questioncode\": \"26\",\n" +
-            "                  \"dateadjustment\": true\n" +
-            "                },\n" +
-            "                {\n" +
-            "                  \"questioncode\": \"27\",\n" +
-            "                  \"dateadjustment\": true\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"returndatetype\": \"E\"\n" +
             "                }\n" +
             "              ]\n" +
             "            }\n" +
@@ -113,7 +147,23 @@ public class DateAdjustmentResponseTest {
             "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
             "            \"nodes\": [\n" +
             "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
             "                \"period\": \"201903\",\n" +
             "                \"survey\": \"023\",\n" +
             "                \"questioncode\": \"20\",\n" +
@@ -121,68 +171,12 @@ public class DateAdjustmentResponseTest {
             "                \"response\": \"20000\"\n" +
             "              },\n" +
             "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
+            "                \"reference\": \"49900534932\",\n" +
             "                \"period\": \"201903\",\n" +
             "                \"survey\": \"023\",\n" +
             "                \"questioncode\": \"21\",\n" +
             "                \"instance\": 0,\n" +
-            "                \"response\": \"15000\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"22\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"1500\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"23\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"1200\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"24\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"1800\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"25\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"600\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"26\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"1200\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"27\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"900\"\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"reference\": \"49900748571\",\n" +
-            "                \"period\": \"201903\",\n" +
-            "                \"survey\": \"023\",\n" +
-            "                \"questioncode\": \"7034\",\n" +
-            "                \"instance\": 0,\n" +
-            "                \"response\": \"6300\"\n" +
+            "                \"response\": \"10000\"\n" +
             "              }\n" +
             "            ]\n" +
             "          }\n" +
@@ -193,254 +187,281 @@ public class DateAdjustmentResponseTest {
             "      \"nodes\": [\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190301\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190302\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190303\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190304\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.1,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190305\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.15,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190306\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.12,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190307\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.17,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190308\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.23,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190309\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.1,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190310\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.13,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190311\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.145,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190312\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.105,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190313\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.15,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190314\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.17,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190315\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.18,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190316\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.17,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190317\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.08,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190318\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190319\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190320\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190321\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190322\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.15,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190323\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.15,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190324\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190325\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.13,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190326\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.14,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190327\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.16,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190328\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.15,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190329\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.13,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190330\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.16,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        },\n" +
             "        {\n" +
             "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
             "          \"tradingdate\": \"20190331\",\n" +
             "          \"domain\": 1,\n" +
             "          \"weight\": 0.13,\n" +
-            "          \"period\": \"201903\",\n" +
-            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodstart\": \"20190301\",\n" +
             "          \"periodend\": \"20190331\"\n" +
             "        }\n" +
             "      ]\n" +
@@ -448,11 +469,9 @@ public class DateAdjustmentResponseTest {
             "    \"allContributordateadjustmentconfigs\": {\n" +
             "      \"nodes\": [\n" +
             "        {\n" +
-            "          \"reference\": \"49900748571\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
             "          \"period\": \"201903\",\n" +
             "          \"survey\": \"023\",\n" +
-            "          \"returnedstartdate\": \"20190301\",\n" +
-            "          \"returnedenddate\": \"20190331\",\n" +
             "          \"longperiodparameter\": 35,\n" +
             "          \"shortperiodparameter\": 27,\n" +
             "          \"averageweekly\": true,\n" +

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -1,0 +1,4 @@
+package uk.gov.ons.collection.test;
+
+public class DateAdjustmentResponseTest {
+}

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -1,9 +1,62 @@
 package uk.gov.ons.collection.test;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import uk.gov.ons.collection.entity.DateAdjustmentResponse;
 
 public class DateAdjustmentResponseTest {
+
+
+    String lambdaOutput = "{\n" +
+            "  \"reference\": \"49900613746\",\n" +
+            "  \"period\": \"201903\",\n" +
+            "  \"survey\": \"023\",\n" +
+            "  \"errorflag\": \"E\",\n" +
+            "  \"dateadjustmenterrorflag\": \"E\",\n" +
+            "  \"daysreturnedperiod\": 25,\n" +
+            "  \"sumtradingweightsoverreturnedperiod\": 29.1,\n" +
+            "  \"actualdaysreturnedperiod\": 25,\n" +
+            "  \"sumtradingweightsoveractualreturnedperiod\": 30.1,\n" +
+            "  \"dateadjustments\": [\n" +
+            "    {\n" +
+            "      \"questioncode\": \"20\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"21\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"22\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "      \n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"23\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"24\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"25\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"questioncode\": \"26\",\n" +
+            "      \"adjusted_value\": \"10000\",\n" +
+            "      \"average_weekly_value\": \"25000\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
     String graphQLOutput = "{\n" +
             "  \"data\": {\n" +
             "    \"allContributors\": {\n" +
@@ -417,6 +470,25 @@ public class DateAdjustmentResponseTest {
             DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(graphQLOutput);
             String output = dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
             System.out.println(output);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void date_adjustment_verify_save_query(){
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(lambdaOutput);
+
+            JSONArray dateAdjustmentsArray = dateAdjustmentResponse.getDateAdjustments();
+            System.out.println(dateAdjustmentsArray.toString());
+            JSONObject responseObject = dateAdjustmentResponse.getJsonQlResponse();
+            System.out.println("Reference: "+ responseObject.getString("reference"));
+            System.out.println("Period: "+ responseObject.getString("period"));
+            System.out.println("Survey: "+ responseObject.getString("survey"));
+            System.out.println("Errorflag: "+ responseObject.get("errorflag"));
+            String dateAdjustmentSaveQuery = dateAdjustmentResponse.buildSaveDateAdjustmentQuery();
+            System.out.println("Save Query: " + dateAdjustmentSaveQuery);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -486,7 +486,6 @@ public class DateAdjustmentResponseTest {
             System.out.println("Reference: "+ responseObject.getString("reference"));
             System.out.println("Period: "+ responseObject.getString("period"));
             System.out.println("Survey: "+ responseObject.getString("survey"));
-            System.out.println("Errorflag: "+ responseObject.get("errorflag"));
             String dateAdjustmentSaveQuery = dateAdjustmentResponse.buildSaveDateAdjustmentQuery();
             System.out.println("Save Query: " + dateAdjustmentSaveQuery);
         } catch (Exception e) {

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.collection.test;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import uk.gov.ons.collection.entity.DateAdjustmentResponse;
 
@@ -67,6 +65,405 @@ public class DateAdjustmentResponseTest {
             "    }\n" +
             "  }\n" +
             "}";
+
+    String noDomainGraphQl = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": null}]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+    String invalidJson = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+    String noCellNumberGraphQl = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": null,\n" +
+            "          \"domain\": 1}]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    String noFormDefinition = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 5,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": []\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"returndatetype\": \"S\"\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"returndatetype\": \"E\"\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190301\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"longperiodparameter\": 35,\n" +
+            "          \"shortperiodparameter\": 27,\n" +
+            "          \"averageweekly\": true,\n" +
+            "          \"settomidpoint\": false,\n" +
+            "          \"settoequalweighted\": false,\n" +
+            "          \"usecalendardays\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    String noReturnDateConfig = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 5,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": []\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190301\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"longperiodparameter\": 35,\n" +
+            "          \"shortperiodparameter\": 27,\n" +
+            "          \"averageweekly\": true,\n" +
+            "          \"settomidpoint\": false,\n" +
+            "          \"settoequalweighted\": false,\n" +
+            "          \"usecalendardays\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+
+    String noTradingWeightsConfig = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 5,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"returndatetype\": \"S\"\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"returndatetype\": \"E\"\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": []\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"longperiodparameter\": 35,\n" +
+            "          \"shortperiodparameter\": 27,\n" +
+            "          \"averageweekly\": true,\n" +
+            "          \"settomidpoint\": false,\n" +
+            "          \"settoequalweighted\": false,\n" +
+            "          \"usecalendardays\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    String noContribDateAdjustmentConfig = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 5,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                }\n" +
+            "                \n" +
+            "              ]\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"returndatetype\": \"S\"\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"formid\": 5,\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"returndatetype\": \"E\"\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190301\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": ["+
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
     String graphQLOutput = "{\n" +
             "  \"data\": {\n" +
             "    \"allContributors\": {\n" +
@@ -493,6 +890,92 @@ public class DateAdjustmentResponseTest {
             "    }\n" +
             "  }\n" +
             "}";
+
+    String noWeightsConfig = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"formid\": 5,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 5,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"11\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"12\",\n" +
+            "                  \"dateadjustment\": false\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            },\n" +
+            "            \"dateadjustmentreturndateconfigsByFormid\": {\n" +
+            "              \"nodes\": []\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"11\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190401\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900534932\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"12\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20190501\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"tradingdate\": \"20190301\",\n" +
+            "          \"domain\": 2,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"periodstart\": \"20190301\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900534932\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"longperiodparameter\": 35,\n" +
+            "          \"shortperiodparameter\": 27,\n" +
+            "          \"averageweekly\": true,\n" +
+            "          \"settomidpoint\": false,\n" +
+            "          \"settoequalweighted\": false,\n" +
+            "          \"usecalendardays\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
     @Test
     void date_adjustment_ExpectedJSONDataEqualsActualJSONData_ParsedData(){
         try {
@@ -523,15 +1006,128 @@ public class DateAdjustmentResponseTest {
     @Test
     void dateAdjustmentConfigDetails_ThrowsAnException__when_domain_is_null(){
 
-        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no contributor for a given survey, reference and periods. Please verify";
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses Either Domain or Results Cell Number is null in Contributor table. Please verify";
         try {
-            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noContributorGraphQLOutput);
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noDomainGraphQl);
             dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
         } catch (Exception e) {
             String actualMessage = e.getMessage();
             assertEquals(expectedErrorMessage, actualMessage);
             assertTrue(true);
 
+        }
+    }
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_cell_number_is_null(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses Either Domain or Results Cell Number is null in Contributor table. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noCellNumberGraphQl);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_invalid_json(){
+
+        String expectedErrorMessage = "Given string could not be converted/processed: org.json.JSONException:";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(invalidJson);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertTrue(actualMessage.contains(expectedErrorMessage));
+            assertTrue(true);
+        }
+    }
+
+
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_no_trading_weights_for_a_given_contributor_domain(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There are no trading weights for a given survey, period and domain in the trading weight contributor. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noWeightsConfig);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_no_contributor_date_adjustment_config(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no contributor date adjustment configuration. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noContribDateAdjustmentConfig);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_no_trading_weights_config(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no trading weight configuration. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noTradingWeightsConfig);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_no_return_date_config(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no Returned Start Date and End date configuration. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noReturnDateConfig);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_no_form_defintion(){
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no FormDefinition for a given survey. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noFormDefinition);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            System.out.println(actualMessage);
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
         }
     }
 

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -1,4 +1,424 @@
 package uk.gov.ons.collection.test;
 
+import org.junit.jupiter.api.Test;
+import uk.gov.ons.collection.entity.DateAdjustmentResponse;
+
 public class DateAdjustmentResponseTest {
+    String graphQLOutput = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900748571\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"formid\": 7,\n" +
+            "          \"status\": \"Form saved\",\n" +
+            "          \"frozensic\": \"41100\",\n" +
+            "          \"resultscellnumber\": 1,\n" +
+            "          \"domain\": 1,\n" +
+            "          \"formByFormid\": {\n" +
+            "            \"survey\": \"023\",\n" +
+            "            \"formid\": 7,\n" +
+            "            \"formdefinitionsByFormid\": {\n" +
+            "              \"nodes\": [\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"20\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"21\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"22\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"23\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"24\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"25\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"26\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                },\n" +
+            "                {\n" +
+            "                  \"questioncode\": \"27\",\n" +
+            "                  \"dateadjustment\": true\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            }\n" +
+            "          },\n" +
+            "          \"responsesByReferenceAndPeriodAndSurvey\": {\n" +
+            "            \"nodes\": [\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"20\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"20000\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"21\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"15000\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"22\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"1500\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"23\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"1200\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"24\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"1800\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"25\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"600\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"26\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"1200\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"27\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"900\"\n" +
+            "              },\n" +
+            "              {\n" +
+            "                \"reference\": \"49900748571\",\n" +
+            "                \"period\": \"201903\",\n" +
+            "                \"survey\": \"023\",\n" +
+            "                \"questioncode\": \"7034\",\n" +
+            "                \"instance\": 0,\n" +
+            "                \"response\": \"6300\"\n" +
+            "              }\n" +
+            "            ]\n" +
+            "          }\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allDateadjustmentweightconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190304\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190305\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.15,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190306\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.12,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190307\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.17,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190308\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.23,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190309\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.1,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190310\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.13,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190311\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.145,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190312\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.105,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190313\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.15,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190314\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.17,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190315\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.18,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190316\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.17,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190317\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.08,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190318\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190319\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190320\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190321\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190322\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.15,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190323\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.15,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190324\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190325\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.13,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190326\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.14,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190327\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.16,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190328\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.15,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190329\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.13,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190330\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.16,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"tradingdate\": \"20190331\",\n" +
+            "          \"domain\": 1,\n" +
+            "          \"weight\": 0.13,\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"periodstart\": \"20190304\",\n" +
+            "          \"periodend\": \"20190331\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"allContributordateadjustmentconfigs\": {\n" +
+            "      \"nodes\": [\n" +
+            "        {\n" +
+            "          \"reference\": \"49900748571\",\n" +
+            "          \"period\": \"201903\",\n" +
+            "          \"survey\": \"023\",\n" +
+            "          \"returnedstartdate\": \"20190301\",\n" +
+            "          \"returnedenddate\": \"20190331\",\n" +
+            "          \"longperiodparameter\": 35,\n" +
+            "          \"shortperiodparameter\": 27,\n" +
+            "          \"averageweekly\": true,\n" +
+            "          \"settomidpoint\": false,\n" +
+            "          \"settoequalweighted\": false,\n" +
+            "          \"usecalendardays\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+    @Test
+    void date_adjustment_ExpectedJSONDataEqualsActualJSONData_ParsedData(){
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(graphQLOutput);
+            String output = dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+            System.out.println(output);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
+++ b/src/test/java/uk/gov/ons/collection/test/DateAdjustmentResponseTest.java
@@ -5,6 +5,9 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import uk.gov.ons.collection.entity.DateAdjustmentResponse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class DateAdjustmentResponseTest {
 
 
@@ -12,7 +15,7 @@ public class DateAdjustmentResponseTest {
             "  \"reference\": \"49900613746\",\n" +
             "  \"period\": \"201903\",\n" +
             "  \"survey\": \"023\",\n" +
-            "  \"errorflag\": \"E\",\n" +
+            "  \"dateadjustmentlengthflag\": \"S\",\n" +
             "  \"dateadjustmenterrorflag\": \"E\",\n" +
             "  \"daysreturnedperiod\": 25,\n" +
             "  \"sumtradingweightsoverreturnedperiod\": 29.1,\n" +
@@ -56,6 +59,13 @@ public class DateAdjustmentResponseTest {
             "      \"average_weekly_value\": \"25000\"\n" +
             "    }\n" +
             "  ]\n" +
+            "}";
+    String noContributorGraphQLOutput = "{\n" +
+            "  \"data\": {\n" +
+            "    \"allContributors\": {\n" +
+            "      \"nodes\": []\n" +
+            "    }\n" +
+            "  }\n" +
             "}";
     String graphQLOutput = "{\n" +
             "  \"data\": {\n" +
@@ -487,10 +497,41 @@ public class DateAdjustmentResponseTest {
     void date_adjustment_ExpectedJSONDataEqualsActualJSONData_ParsedData(){
         try {
             DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(graphQLOutput);
-            String output = dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
-            System.out.println(output);
+            String expectedConfig = "{\"usecalendardays\":false,\"returnedenddate\":\"20190501\",\"period\":\"201903\",\"weights\":[{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190301\",\"weight\":0.1},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190302\",\"weight\":0.1},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190303\",\"weight\":0.1},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190304\",\"weight\":0.1},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190305\",\"weight\":0.15},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190306\",\"weight\":0.12},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190307\",\"weight\":0.17},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190308\",\"weight\":0.23},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190309\",\"weight\":0.1},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190310\",\"weight\":0.13},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190311\",\"weight\":0.145},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190312\",\"weight\":0.105},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190313\",\"weight\":0.15},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190314\",\"weight\":0.17},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190315\",\"weight\":0.18},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190316\",\"weight\":0.17},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190317\",\"weight\":0.08},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190318\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190319\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190320\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190321\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190322\",\"weight\":0.15},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190323\",\"weight\":0.15},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190324\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190325\",\"weight\":0.13},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190326\",\"weight\":0.14},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190327\",\"weight\":0.16},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190328\",\"weight\":0.15},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190329\",\"weight\":0.13},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190330\",\"weight\":0.16},{\"period\":\"201903\",\"domain\":1,\"survey\":\"023\",\"tradingdate\":\"20190331\",\"weight\":0.13}],\"reference\":\"49900534932\",\"longperiodparameter\":35,\"returnedstartdate\":\"20190401\",\"settomidpoint\":false,\"cellnumber\":1,\"settoequalweighted\":false,\"domain\":1,\"survey\":\"023\",\"responses\":[{\"instance\":0,\"response\":\"20000\",\"questioncode\":\"20\"},{\"instance\":0,\"response\":\"10000\",\"questioncode\":\"21\"}],\"shortperiodparameter\":27,\"averageweekly\":true,\"frozensic\":\"41100\",\"periodstart\":\"20190301\",\"periodend\":\"20190331\"}";
+            String actualConfig = dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+            assertEquals(expectedConfig, actualConfig);
         } catch (Exception e) {
-            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException_when_no_contributor(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no contributor for a given survey, reference and periods. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noContributorGraphQLOutput);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
+        }
+    }
+
+    @Test
+    void dateAdjustmentConfigDetails_ThrowsAnException__when_domain_is_null(){
+
+        String expectedErrorMessage = "Problem in parsing Selective Editing GraphQL responses There is no contributor for a given survey, reference and periods. Please verify";
+        try {
+            DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(noContributorGraphQLOutput);
+            dateAdjustmentResponse.parseDateAdjustmentQueryResponse();
+        } catch (Exception e) {
+            String actualMessage = e.getMessage();
+            assertEquals(expectedErrorMessage, actualMessage);
+            assertTrue(true);
+
         }
     }
 
@@ -499,16 +540,11 @@ public class DateAdjustmentResponseTest {
         try {
             DateAdjustmentResponse dateAdjustmentResponse = new DateAdjustmentResponse(lambdaOutput);
 
-            JSONArray dateAdjustmentsArray = dateAdjustmentResponse.getDateAdjustments();
-            System.out.println(dateAdjustmentsArray.toString());
-            JSONObject responseObject = dateAdjustmentResponse.getJsonQlResponse();
-            System.out.println("Reference: "+ responseObject.getString("reference"));
-            System.out.println("Period: "+ responseObject.getString("period"));
-            System.out.println("Survey: "+ responseObject.getString("survey"));
-            String dateAdjustmentSaveQuery = dateAdjustmentResponse.buildSaveDateAdjustmentQuery();
-            System.out.println("Save Query: " + dateAdjustmentSaveQuery);
+            String expectedOutput = "{\"query\": \"mutation upsertDateAdjustment{savedateadjustment(input: {arg0:[{reference: \\\"49900613746\\\",period: \\\"201903\\\",survey: \\\"023\\\",questioncode: \\\"20\\\",instance: 0,adjustedresponse: \\\"10000\\\",averageweeklyadjustedresponse: \\\"25000\\\",createdby: \\\"fisdba\\\"";
+            String actualOutput = dateAdjustmentResponse.buildSaveDateAdjustmentQuery();
+            assertTrue(actualOutput.contains(expectedOutput));
         } catch (Exception e) {
-            e.printStackTrace();
+            assertTrue(false);
         }
     }
 }


### PR DESCRIPTION
# Description
This PR covers the business layer changes for the Date Adjustment processing. This includes the two API calls one for getting configuration, another for saving adjusted responses and corresponding unit tests.
Story Link: https://collaborate2.ons.gov.uk/jira/browse/SPP-828

# How to test?
Before executing Lambda
1. Go to UI 
2. Go to RSI survey and any form for example Form 6 and Period 201903 - Any reference is OK
3. Q11 and Q12 values are mandatory and for period 201903 enter 
    Period start date = 20190304
    Period end date = 20190328
4. For period 201904 period enter 
Period start date = 20190404
Period end date  = 20190428
5. And also enter the values for the numerical questions Q20 to Q26
6. Save the Form
7. To test this, you can use the SPP-828 environment and execute the Lambda **'spp-es-takeon-validation-spp828-date-adjustment'** manually by updating the test event with the following JSON Payload and checking the Cloudwatch logs:
  
{ "reference": "11111111111", "period": "201904", "survey": "023" }

*** Ask me for references that work / loaded into the database.
8. Refresh the UI for the above reference period and Form and you can see the AdjustedResponse if any
9. Verify database 
  Response Table - Column AdjustedResponse and AverageWeeklyAdjustedResponse
  ContributorDateAdjustment Table - The corresponding score flags and audit information.

# Unit Tests
You can run java unit tests using:   mvn clean test

# Code Coverage
You can verify code coverage using:   awk -F"," '{ instructions += $4 + $5; covered += $5 } END { print covered, "/", instructions, " instructions covered"; print 100*covered/instructions, "% covered" }' target/site/jacoco/jacoco.csv

# Check Style errors
You can verify check style errors using :   mvn package install

# Links
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=17467155