### PR TITLE
Bug spp 1457 nullcheck

### DIFF
--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -200,7 +200,8 @@ public class DateAdjustmentResponse {
                 boolean dateAdjustmentFlag = eachFormDefinitionObject.getBoolean("dateadjustment");
                 boolean matchFound = false;
                 for (int j = 0; j < responseArray.length(); j++) {
-                    String response = responseArray.getJSONObject(j).getString(RESPONSE);
+                    String response = (responseArray.getJSONObject(j).isNull(RESPONSE))
+                            ? EMPTY_SPACE : responseArray.getJSONObject(j).getString(RESPONSE);
                     if (questionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE)) && dateAdjustmentFlag) {
                         eachResponseObject.put(QUESTION_CODE, questionCode);
                         eachResponseObject.put(RESPONSE, response);

--- a/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
+++ b/src/main/java/uk/gov/ons/collection/entity/DateAdjustmentResponse.java
@@ -200,6 +200,7 @@ public class DateAdjustmentResponse {
                 boolean dateAdjustmentFlag = eachFormDefinitionObject.getBoolean("dateadjustment");
                 boolean matchFound = false;
                 for (int j = 0; j < responseArray.length(); j++) {
+                    // Performed null check
                     String response = (responseArray.getJSONObject(j).isNull(RESPONSE))
                             ? EMPTY_SPACE : responseArray.getJSONObject(j).getString(RESPONSE);
                     if (questionCode.equals(responseArray.getJSONObject(j).getString(QUESTION_CODE)) && dateAdjustmentFlag) {


### PR DESCRIPTION
# Description
Handled null or empty responses during Date Adjustment process

# How to test?
Using the UI in the spp829-add-dateadj-to-pipeline environment, update values for question 11 & 12 and 20-26 for reference: 12000613746, Survey: 023, Period: 201903 and if the results come back for Validation outputs, you know the pipeline has run. You can also check the Cloud watch logs to verify this.

# Links
https://collaborate2.ons.gov.uk/jira/browse/SPP-1457