### PR TITLE
Removed logging for selection GraphQL Query

### DIFF
--- a/src/main/java/uk/gov/ons/collection/controller/ContributorController.java
+++ b/src/main/java/uk/gov/ons/collection/controller/ContributorController.java
@@ -95,7 +95,6 @@ public class ContributorController {
         try {
             SelectionFileQuery fileQuery =  new SelectionFileQuery(selectionData, qlService);
             String loadQuery = fileQuery.buildSaveSelectionFileQuery();
-            log.info("Load Selection Query: " + loadQuery);
             String  response = qlService.qlSearch(loadQuery);
             log.info("Load Selection File response: " + response);
             //Process if any GraphQL exception


### PR DESCRIPTION
# Description
Removed logging for Selection File GraphQL Query

# How to test?
Load a selection file and verify Cloud Watch logs and you should not see GraphQL Query printing in the logs

# Links
https://collaborate2.ons.gov.uk/jira/secure/RapidBoard.jspa?rapidView=1583&projectKey=SPP&selectedIssue=SPP-1486